### PR TITLE
Trim whitespace from emote names

### DIFF
--- a/emote/tests/test_format.py
+++ b/emote/tests/test_format.py
@@ -1,0 +1,19 @@
+import unittest
+from types import SimpleNamespace
+
+from emote.utils.format import clean_emote_name, extract_emote_details
+
+
+class FormatTests(unittest.TestCase):
+    def test_clean_emote_name_trims_whitespace(self):
+        self.assertEqual(clean_emote_name(": nick:"), "nick")
+
+    def test_extract_emote_details_trims_whitespace(self):
+        message = SimpleNamespace(content=": nick:")
+        name, effects = extract_emote_details(message)
+        self.assertEqual(name, "nick")
+        self.assertEqual(effects, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/emote/utils/format.py
+++ b/emote/utils/format.py
@@ -26,7 +26,9 @@ def clean_emote_name(emote_name: str):
     :param emote_name: The name of the emote to be cleaned.
     :return: The cleaned emote name where the prefix and postfix character sequence is removed, if it exists.
     """
-    return emote_name[2:-1] if emote_name.startswith(":~") else emote_name[1:-1]
+    return (
+        emote_name[2:-1] if emote_name.startswith(":~") else emote_name[1:-1]
+    ).strip()
 
 
 def extract_emote_details(message: discord.Message):


### PR DESCRIPTION
## Summary
- strip leading/trailing spaces from colon-wrapped emote names
- add unit tests verifying emote name trimming

## Testing
- `pytest`
- `pytest emote/tests/test_format.py`


------
https://chatgpt.com/codex/tasks/task_e_689ab361a418832592c4ce7f91ee8177