### PR TITLE
Add explode emote effect

### DIFF
--- a/emote/slash_commands.py
+++ b/emote/slash_commands.py
@@ -179,6 +179,7 @@ class SlashCommands(commands.Cog):
         "slow": {'func': effect.slow, 'perm': 'everyone', 'single_use': True, 'blocking': True},  # Alias for speed
         "shake": {'func': effect.shake, 'perm': 'everyone', 'single_use': True, 'blocking': True},
         "rainbow": {'func': effect.rainbow, 'perm': 'everyone', 'single_use': True, 'blocking': True},
+        "explode": {'func': effect.explode, 'perm': 'everyone', 'single_use': True, 'blocking': True},
         "spin": {'func': effect.spin, 'perm': 'everyone', 'single_use': True, 'blocking': True}
     }
     reaction_effects = {
@@ -190,6 +191,7 @@ class SlashCommands(commands.Cog):
         "🫨": effect.shake,
         "🔃": effect.flip,
         "🌈": effect.rainbow,
+        "💥": effect.explode,
     }
 
     latency_enabled = False

--- a/emote/utils/effects.py
+++ b/emote/utils/effects.py
@@ -4,12 +4,17 @@ import random
 import traceback
 from dataclasses import dataclass, field
 from datetime import datetime
+from pathlib import Path
 from typing import Optional, Dict
 
 import aiohttp
 import numpy as np
-from PIL import Image, ImageOps
+from PIL import Image, ImageOps, ImageDraw
 from skimage import color
+
+
+RESOURCE_BASE_PATH = Path(__file__).resolve().parent.parent / "res"
+Resampling = getattr(Image, "Resampling", Image)
 
 
 @dataclass
@@ -589,6 +594,185 @@ def invert(emote: Emote) -> Emote:
         line_number = traceback.extract_tb(err.__traceback__)[-1].lineno
         emote.errors["invert"] = f"Error inverting: {err} at line {line_number}"
         return emote
+
+    return emote
+
+
+def _generate_explosion_frame(base_image: Image.Image, amount: float) -> Image.Image:
+    width, height = base_image.size
+    ease_w = (amount / width) * 4.0
+    half_w = width / 2.0
+    half_h = height / 2.0
+    quality = 0.5
+    step_unit = max((0.5 / half_w) * quality, 1.0 / max(width, height))
+
+    result = Image.new("RGBA", base_image.size, (255, 255, 255, 255))
+    i = 0.0
+    while i < 0.5:
+        r = i * 2.0
+        x = r * half_w
+        y = r * half_h
+        xw = width - (x * 2.0)
+        rx = x * ease_w
+        ry = y * ease_w
+        rw = width - (rx * 2.0)
+        rh = height - (ry * 2.0)
+
+        if abs(rw) < 1e-6 or abs(rh) < 1e-6:
+            i += step_unit
+            continue
+
+        coeffs = (
+            rw / width,
+            0.0,
+            rx,
+            0.0,
+            rh / height,
+            ry,
+        )
+        transformed = base_image.transform(
+            (width, height),
+            Image.AFFINE,
+            coeffs,
+            resample=Resampling.BICUBIC,
+            fillcolor=(255, 255, 255, 255),
+        )
+
+        radius = max(0.0, xw / 2.0)
+        if radius <= 0:
+            break
+
+        mask = Image.new("L", (width, height), 0)
+        draw = ImageDraw.Draw(mask)
+        cx, cy = half_w, half_h
+        draw.ellipse((cx - radius, cy - radius, cx + radius, cy + radius), fill=255)
+        result = Image.composite(transformed, result, mask)
+
+        i += step_unit
+
+    return result
+
+
+def explode(emote: Emote, explosion_type: str = "nuke") -> Emote:
+    """
+    Generates an expanding explosion animation and appends a themed blast sequence.
+
+    User:
+        Makes the emote detonate into an explosion.
+        Default output is the nuke explosion.
+        Other explosion types: earth, house.
+
+        Usage:
+            :emote_explode:            - Uses the default nuke explosion.
+            :emote_explode(earth):     - Uses the earth-shattering explosion.
+            :emote_explode(house):     - Uses the house explosion sequence.
+
+        Works best with static images. Animated inputs use only the first frame.
+        This effect can only be used once per emote.
+
+    Parameters:
+        emote (Emote): The emote object containing the image data.
+        explosion_type (str): Which explosion sequence to append. Defaults to "nuke".
+
+    Returns:
+        Emote: The updated emote object with the explosion animation appended.
+    """
+
+    if emote.img_data is None:
+        emote.errors["explode"] = "No image data available."
+        return emote
+
+    explosion_key = "nuke"
+    if explosion_type is not None:
+        try:
+            parsed_type = str(explosion_type).strip().lower()
+            if parsed_type:
+                explosion_key = parsed_type
+        except Exception:
+            emote.issues["explode_type_parse"] = "Invalid explosion type format, using default nuke."
+
+    available_sequences = {
+        "nuke": RESOURCE_BASE_PATH / "nuke",
+        "earth": RESOURCE_BASE_PATH / "earth",
+        "house": RESOURCE_BASE_PATH / "house",
+    }
+
+    sequence_path = available_sequences.get(explosion_key)
+    if sequence_path is None or not sequence_path.exists():
+        emote.issues["explode_type"] = f"Unknown explosion type '{explosion_key}', defaulting to nuke."
+        explosion_key = "nuke"
+        sequence_path = available_sequences["nuke"]
+
+    try:
+        with Image.open(io.BytesIO(emote.img_data)) as img:
+            if getattr(img, "is_animated", False):
+                try:
+                    img.seek(0)
+                except EOFError:
+                    pass
+            source_frame = img.convert("RGBA")
+    except Exception as err:
+        emote.errors["explode_load"] = f"Error loading image: {err}"
+        return emote
+
+    canvas_size = (512, 512)
+    base_canvas = Image.new("RGBA", canvas_size, (255, 255, 255, 255))
+    try:
+        resized_frame = source_frame.resize(canvas_size, resample=Resampling.LANCZOS)
+    except Exception:
+        resized_frame = source_frame.resize(canvas_size)
+    base_canvas.alpha_composite(resized_frame)
+
+    explosion_amounts = [10, 20, 50, 100]
+    generated_frames = [base_canvas]
+    for amount in explosion_amounts:
+        generated_frames.append(_generate_explosion_frame(base_canvas, amount))
+
+    resource_frames = sorted(sequence_path.glob("*.gif"))
+    if not resource_frames:
+        emote.errors["explode_resources"] = f"No frames found for explosion '{explosion_key}'."
+        return emote
+
+    appended_frames: list[Image.Image] = []
+    missing_details: list[str] = []
+    for frame_path in resource_frames:
+        try:
+            with Image.open(frame_path) as frame_img:
+                appended_frames.append(frame_img.convert("RGBA"))
+        except Exception as err:
+            missing_details.append(f"{frame_path.name}: {err}")
+
+    if missing_details:
+        emote.issues["explode_missing_frames"] = "; ".join(missing_details)
+
+    if not appended_frames:
+        emote.errors["explode_resources"] = f"Unable to load explosion frames for '{explosion_key}'."
+        return emote
+
+    total_frames = generated_frames + appended_frames
+    durations = [40] * len(total_frames)
+
+    output_buffer = io.BytesIO()
+    try:
+        total_frames[0].save(
+            output_buffer,
+            format="GIF",
+            save_all=True,
+            append_images=total_frames[1:],
+            duration=durations,
+            loop=0,
+            disposal=2,
+        )
+    except Exception as err:
+        emote.errors["explode_save"] = f"Failed to build explosion GIF: {err}"
+        return emote
+
+    emote.img_data = output_buffer.getvalue()
+
+    original_path = Path(emote.file_path)
+    emote.file_path = f"{original_path.stem}_explode.gif"
+    emote.notes["explode_type"] = explosion_key
+    emote.notes["explode_frames"] = str(len(total_frames))
 
     return emote
 


### PR DESCRIPTION
## Summary
- add an explode effect that generates expansion frames and appends themed blast animations
- register the explode effect for slash commands and reaction shortcuts

## Testing
- `pytest emote/tests/test_format.py` *(fails: missing redbot dependency in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6b3fc1c448325b2e6c6d4b30b2c76