### PR TITLE
Add explode emote effect

### DIFF
--- a/emote/slash_commands.py
+++ b/emote/slash_commands.py
@@ -178,6 +178,7 @@ class SlashCommands(commands.Cog):
         "fast": {'func': effect.fast, 'perm': 'everyone', 'single_use': True, 'blocking': True},  # Alias for speed
         "slow": {'func': effect.slow, 'perm': 'everyone', 'single_use': True, 'blocking': True},  # Alias for speed
         "shake": {'func': effect.shake, 'perm': 'everyone', 'single_use': True, 'blocking': True},
+        "explode": {'func': effect.explode, 'perm': 'everyone', 'single_use': True, 'blocking': True},
         "rainbow": {'func': effect.rainbow, 'perm': 'everyone', 'single_use': True, 'blocking': True},
         "spin": {'func': effect.spin, 'perm': 'everyone', 'single_use': True, 'blocking': True}
     }
@@ -190,6 +191,7 @@ class SlashCommands(commands.Cog):
         "🫨": effect.shake,
         "🔃": effect.flip,
         "🌈": effect.rainbow,
+        "💥": effect.explode,
     }
 
     latency_enabled = False


### PR DESCRIPTION
## Summary
- add a radial explosion effect that composites themed overlay animations using bundled assets
- register the explode effect for slash command usage and reaction shortcuts

## Testing
- python -m compileall emote/utils/effects.py emote/slash_commands.py

------
https://chatgpt.com/codex/tasks/task_e_68d6b3fc1c448325b2e6c6d4b30b2c76