### PR TITLE
Gen3: disallow newlines, support Unicode letters in three-word rule, reply on ✨ forgive

### DIFF
--- a/gen3/slash_commands.py
+++ b/gen3/slash_commands.py
@@ -1106,8 +1106,9 @@ class SlashCommands(commands.Cog):
 
                     removed = 1
                     plural = "strike" if removed == 1 else "strikes"
-                    await message.channel.send(
+                    await message.reply(
                         f"Removed {removed} {plural} from {target_user.mention}! ✨ They now have {new_count}/3 strikes.",
+                        mention_author=False,
                     )
                 except Exception:
                     pass

--- a/gen3/tests/test_three_word.py
+++ b/gen3/tests/test_three_word.py
@@ -35,6 +35,20 @@ class ThreeWordRuleTests(unittest.TestCase):
         self.assertTrue(result["passes"])
         self.assertEqual(result["analysis"]["number_count"], 1)
 
+    def test_unicode_letters_count_as_single_word(self):
+        message = "rōnin are cool"
+        result = asyncio.run(three_word_rule(message))
+
+        self.assertTrue(result["passes"])
+        self.assertEqual(result["analysis"]["word_count"], 3)
+
+    def test_line_breaks_are_not_allowed(self):
+        message = "hello\nworld today"
+        result = asyncio.run(three_word_rule(message))
+
+        self.assertFalse(result["passes"])
+        self.assertIn("Line breaks are not allowed", result["reason"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Motivation
- Prevent multi-line submissions for the three-word gimmick by rejecting messages with line breaks.
- Allow words that contain Unicode letters (e.g. `rōnin`) to be treated as single tokens instead of being split by symbol heuristics.
- Make the forgiveness sparkle reaction (`✨`) produce a direct reply to the reacted message for better context.

### Description
- Updated three-word parsing to use `LETTER_PATTERN` and `ALNUM_PATTERN` with `HYPHENATED_PATTERN`/`WORD_PATTERN` so Unicode letters count as word characters and hyphenated tokens are preserved.
- Added an explicit newline check in `three_word_rule` to reject messages containing `\n` or `\r` with a clear reason string.
- Switched the sparkle forgiveness response from `message.channel.send` to `message.reply(..., mention_author=False)` so the bot replies to the reacted message.
- Added unit tests in `gen3/tests/test_three_word.py` to cover Unicode-letter words and newline rejection, and adjusted existing hyphenation tests.

### Testing
- Ran the test script directly with `python gen3/tests/test_three_word.py`, which executed 5 tests and passed (`OK`).
- Attempted `python -m unittest gen3/tests/test_three_word.py` which failed to import `redbot` due to the test environment lacking Red dependencies (expected in this repo environment).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d87580fe88325a8d22a390f04f19a)