### PR TITLE
Require active season and add explicit start/end DB methods; handle missing season in commands

### DIFF
--- a/gen3/slash_commands.py
+++ b/gen3/slash_commands.py
@@ -28,7 +28,7 @@ from gen3.rules.apple_orange import apple_orange_rule
 from gen3.rules.three_word import three_word_rule
 from gen3.rules.word_chain import get_position_emoji, reset_word_chain_state, word_chain_rule
 # Use the dedicated Gen3Database class
-from gen3.utils.database import Gen3Database
+from gen3.utils.database import Gen3Database, NoActiveSeasonError
 
 # Create a global database instance
 db = Gen3Database()
@@ -290,8 +290,8 @@ class SlashCommands(commands.Cog):
         # Reset the word-chain state (fresh start when rules change)
         reset_word_chain_state()
 
-    @season.command(name="new", description="End the current Gen3 season and start a new one")
-    @app_commands.describe(label="Optional label for the new season")
+    @season.command(name="new", description="Start a new Gen3 season")
+    @app_commands.describe(label="Optional label for the season")
     @commands.guild_only()
     @app_commands.check(is_owner_or_manage_guild)
     async def season_new(self, interaction: discord.Interaction, label: str | None = None):
@@ -299,49 +299,15 @@ class SlashCommands(commands.Cog):
             await interaction.response.send_message("This command can only be used in a guild.", ephemeral=True)
             return
 
-        old_season, new_season = await db.start_new_season(interaction.guild_id, label=label)
-
-        cleared_users: set[int] = set()
-        if old_season:
-            try:
-                struck_rows = await db.fetch_struck_out_for_season(
-                    interaction.guild_id, int(old_season["id"])
-                )
-            except Exception:
-                struck_rows = []
-
-            if struck_rows:
-                target_channels = await self._get_enabled_text_channels(interaction.guild)
-
-                def extract_user_id(row) -> int:
-                    try:
-                        return int(row["user_id"])
-                    except Exception:
-                        return int(row[0])
-
-                for row in struck_rows:
-                    uid = extract_user_id(row)
-                    member = interaction.guild.get_member(uid)
-                    if not member:
-                        continue
-                    for ch in target_channels:
-                        try:
-                            await ch.set_permissions(member, overwrite=None, reason="Gen3 season reset")
-                            cleared_users.add(uid)
-                        except Exception:
-                            continue
+        new_season = await db.start_season(interaction.guild_id, label=label)
+        if new_season is None:
+            await interaction.response.send_message(
+                "There is already an active season. End it first with `/gen3 season end`.",
+                ephemeral=True,
+            )
+            return
 
         embed = discord.Embed(title="New Gen3 Season Started!", color=discord.Color.green())
-        if old_season:
-            embed.add_field(
-                name="Previous Season",
-                value=(
-                    f"ID: {old_season['id']}\n"
-                    f"Label: {old_season.get('label') or '—'}\n"
-                    f"Duration: {format_dt(old_season.get('started_at'))} → {format_dt(old_season.get('ended_at'))}"
-                ),
-                inline=False,
-            )
 
         embed.add_field(
             name="Active Season",
@@ -353,8 +319,32 @@ class SlashCommands(commands.Cog):
             inline=False,
         )
 
-        if cleared_users:
-            embed.set_footer(text=f"Cleared channel overrides for {len(cleared_users)} users from the previous season.")
+        await interaction.response.send_message(embed=embed)
+
+    @season.command(name="end", description="End the current Gen3 season")
+    @commands.guild_only()
+    @app_commands.check(is_owner_or_manage_guild)
+    async def season_end(self, interaction: discord.Interaction):
+        if interaction.guild is None:
+            await interaction.response.send_message("This command can only be used in a guild.", ephemeral=True)
+            return
+
+        ended_season = await db.end_active_season(interaction.guild_id)
+        if ended_season is None:
+            await interaction.response.send_message("There is no active season to end.", ephemeral=True)
+            return
+
+        embed = discord.Embed(title="Gen3 Season Ended", color=discord.Color.orange())
+        embed.add_field(
+            name="Ended Season",
+            value=(
+                f"ID: {ended_season['id']}\n"
+                f"Label: {ended_season.get('label') or '—'}\n"
+                f"Duration: {format_dt(ended_season.get('started_at'))} → {format_dt(ended_season.get('ended_at'))}"
+            ),
+            inline=False,
+        )
+        embed.set_footer(text="Use `/gen3 season new` when you are ready to start the next season.")
 
         await interaction.response.send_message(embed=embed)
 
@@ -517,10 +507,24 @@ class SlashCommands(commands.Cog):
     ):
         # Remove the specified number of strikes, capping at 0
         new_count = None
-        for _ in range(int(value)):
-            new_count = await db.decrease_strike(user.id, interaction.guild_id)
+        try:
+            for _ in range(int(value)):
+                new_count = await db.decrease_strike(user.id, interaction.guild_id)
+        except NoActiveSeasonError:
+            await interaction.response.send_message(
+                "There is no active season. Start one with `/gen3 season new`.",
+                ephemeral=True,
+            )
+            return
         if new_count is None:
-            new_count = await db.get_strikes(user.id, interaction.guild_id)
+            try:
+                new_count = await db.get_strikes(user.id, interaction.guild_id)
+            except NoActiveSeasonError:
+                await interaction.response.send_message(
+                    "There is no active season. Start one with `/gen3 season new`.",
+                    ephemeral=True,
+                )
+                return
 
         if new_count < 3:
             # Unblock user in any enabled Gen3 channels
@@ -548,7 +552,14 @@ class SlashCommands(commands.Cog):
     @commands.guild_only()
     @app_commands.check(is_owner_or_manage_guild)
     async def forgive_user(self, interaction: discord.Interaction, user: discord.Member):
-        await db.reset_strikes(user.id, interaction.guild_id)
+        try:
+            await db.reset_strikes(user.id, interaction.guild_id)
+        except NoActiveSeasonError:
+            await interaction.response.send_message(
+                "There is no active season. Start one with `/gen3 season new`.",
+                ephemeral=True,
+            )
+            return
 
         channel = next(iter(await self._get_enabled_text_channels(interaction.guild)), None)
 
@@ -590,7 +601,14 @@ class SlashCommands(commands.Cog):
     @app_commands.describe(user="User to check strikes for")
     @commands.guild_only()
     async def view_strikes(self, interaction: discord.Interaction, user: discord.Member):
-        strikes = await db.get_strikes(user.id, interaction.guild_id)
+        try:
+            strikes = await db.get_strikes(user.id, interaction.guild_id)
+        except NoActiveSeasonError:
+            await interaction.response.send_message(
+                "There is no active season. Start one with `/gen3 season new`.",
+                ephemeral=True,
+            )
+            return
         await interaction.response.send_message(
             f"{user.mention} has {strikes}/3 strikes. Please be careful! ⚠️",
             ephemeral=False
@@ -615,6 +633,12 @@ class SlashCommands(commands.Cog):
         try:
             active_rows = await db.fetch_standings(guild.id)
             struck_rows = await db.fetch_struck_out(guild.id)
+        except NoActiveSeasonError:
+            await interaction.response.send_message(
+                "There is no active season. Start one with `/gen3 season new`.",
+                ephemeral=True,
+            )
+            return
         except Exception:
             await interaction.response.send_message(
                 "Could not fetch standings due to a database error.",
@@ -1049,7 +1073,10 @@ class SlashCommands(commands.Cog):
                     demo_mode = await self._channel_is_demo(message.channel)
                     current_strikes = 0
                     if author_id and not demo_mode:
-                        current_strikes = await db.get_strikes(author_id, guild_id)
+                        try:
+                            current_strikes = await db.get_strikes(author_id, guild_id)
+                        except NoActiveSeasonError:
+                            current_strikes = 0
                     # Use the effective rule for this channel, honoring channel overrides
                     try:
                         effective_rule = await self._get_effective_rule(message.guild, message.channel)
@@ -1110,6 +1137,8 @@ class SlashCommands(commands.Cog):
                         f"Removed {removed} {plural} from {target_user.mention}! ✨ They now have {new_count}/3 strikes.",
                         mention_author=False,
                     )
+                except NoActiveSeasonError:
+                    return
                 except Exception:
                     pass
                 return
@@ -1210,7 +1239,10 @@ class SlashCommands(commands.Cog):
         if demo_mode:
             strikes = 0
         else:
-            strikes = await db.get_strikes(user_id, guild_id)
+            try:
+                strikes = await db.get_strikes(user_id, guild_id)
+            except NoActiveSeasonError:
+                return
         rule_key = await self._get_effective_rule(message.guild, channel)
 
         analysis = await check_gen3_rules(content, strikes, active_rule=rule_key)
@@ -1279,9 +1311,15 @@ class SlashCommands(commands.Cog):
 
             # Compute strike count (increment only when not exempt)
             if exempt_channel:
-                current_strikes = await db.get_strikes(user.id, guild_id)
+                try:
+                    current_strikes = await db.get_strikes(user.id, guild_id)
+                except NoActiveSeasonError:
+                    return
             else:
-                current_strikes = await db.increment_strike(user.id, guild_id)
+                try:
+                    current_strikes = await db.increment_strike(user.id, guild_id)
+                except NoActiveSeasonError:
+                    return
 
             if exempt_channel:
                 # In strike-exempt channels: warn only, do not add a strike or lock out

--- a/gen3/utils/database.py
+++ b/gen3/utils/database.py
@@ -18,6 +18,10 @@ import os
 import asyncpg
 
 
+class NoActiveSeasonError(RuntimeError):
+    """Raised when an operation requires an active season but none exists."""
+
+
 class Gen3Database:
     """
     Dedicated database class for Gen3 cog operations.
@@ -203,6 +207,30 @@ class Gen3Database:
         )
         return await self.execute_query(query, guild_id, label, fetchrow=True)
 
+    async def start_season(self, guild_id: int, label: str | None = None) -> asyncpg.Record | None:
+        """Start a new season only when no active season exists for the guild."""
+        if self.pool is None:
+            await self.init_pool()
+
+        async with self.pool.acquire() as connection:
+            async with connection.transaction():
+                current = await connection.fetchrow(
+                    "SELECT * FROM gen3.seasons WHERE guild_id = $1 AND is_active = TRUE LIMIT 1;",
+                    guild_id,
+                )
+                if current:
+                    return None
+
+                return await connection.fetchrow(
+                    """
+                    INSERT INTO gen3.seasons (guild_id, label, started_at, is_active)
+                    VALUES ($1, $2, NOW(), TRUE)
+                    RETURNING *;
+                    """,
+                    guild_id,
+                    label,
+                )
+
     async def start_new_season(
         self, guild_id: int, label: str | None = None
     ) -> tuple[asyncpg.Record | None, asyncpg.Record]:
@@ -241,18 +269,44 @@ class Gen3Database:
 
                 return current, new_season
 
+    async def end_active_season(self, guild_id: int) -> asyncpg.Record | None:
+        """Close the active season for a guild without creating a new one."""
+        if self.pool is None:
+            await self.init_pool()
+
+        async with self.pool.acquire() as connection:
+            async with connection.transaction():
+                current = await connection.fetchrow(
+                    "SELECT * FROM gen3.seasons WHERE guild_id = $1 AND is_active = TRUE LIMIT 1;",
+                    guild_id,
+                )
+                if not current:
+                    return None
+
+                await connection.execute(
+                    "UPDATE gen3.seasons SET is_active = FALSE, ended_at = COALESCE(ended_at, NOW()) WHERE id = $1;",
+                    current["id"],
+                )
+
+                return await connection.fetchrow(
+                    "SELECT * FROM gen3.seasons WHERE id = $1;",
+                    current["id"],
+                )
+
     async def list_seasons(self, guild_id: int):
         """Return all seasons for a guild ordered by creation."""
         query = "SELECT * FROM gen3.seasons WHERE guild_id = $1 ORDER BY id ASC;"
         return await self.fetch_query(query, guild_id)
 
-    async def _get_active_season_id(self, guild_id: int) -> int:
-        season = await self.get_or_create_active_season(guild_id)
+    async def _require_active_season_id(self, guild_id: int) -> int:
+        season = await self.get_active_season(guild_id)
+        if not season:
+            raise NoActiveSeasonError("No active season for this guild.")
         return int(season["id"])
 
     async def increment_strike(self, user_id: int, guild_id: int) -> int:
         """Increment the strike count for a user in a given guild's active season."""
-        season_id = await self._get_active_season_id(guild_id)
+        season_id = await self._require_active_season_id(guild_id)
         query = (
             "INSERT INTO gen3.strikes (user_id, guild_id, season_id, strikes) "
             "VALUES ($1, $2, $3, 1) "
@@ -264,7 +318,7 @@ class Gen3Database:
 
     async def decrease_strike(self, user_id: int, guild_id: int) -> int:
         """Decrement the strike count for a user in a given guild."""
-        season_id = await self._get_active_season_id(guild_id)
+        season_id = await self._require_active_season_id(guild_id)
         query = (
             "UPDATE gen3.strikes "
             "SET strikes = GREATEST(strikes - 1, 0) "
@@ -278,13 +332,13 @@ class Gen3Database:
 
     async def get_strikes(self, user_id: int, guild_id: int) -> int:
         """Get the strike count for a user in a given guild."""
-        season_id = await self._get_active_season_id(guild_id)
+        season_id = await self._require_active_season_id(guild_id)
         query = "SELECT strikes FROM gen3.strikes WHERE user_id = $1 AND guild_id = $2 AND season_id = $3"
         return await self.execute_query(query, user_id, guild_id, season_id, fetchval=True) or 0
 
     async def reset_strikes(self, user_id: int, guild_id: int) -> None:
         """Reset the strike count for a user in a given guild without losing message count."""
-        season_id = await self._get_active_season_id(guild_id)
+        season_id = await self._require_active_season_id(guild_id)
         query = (
             "INSERT INTO gen3.strikes (user_id, guild_id, season_id, strikes, msg_count) "
             "VALUES ($1, $2, $3, 0, 0) "
@@ -294,7 +348,7 @@ class Gen3Database:
 
     async def ensure_user_row(self, user_id: int, guild_id: int) -> None:
         """Ensure a row exists for the user with strikes=0 and msg_count=0."""
-        season_id = await self._get_active_season_id(guild_id)
+        season_id = await self._require_active_season_id(guild_id)
         query = (
             "INSERT INTO gen3.strikes (user_id, guild_id, season_id, strikes, msg_count) "
             "VALUES ($1, $2, $3, 0, 0) ON CONFLICT (user_id, guild_id, season_id) DO NOTHING;"
@@ -303,7 +357,7 @@ class Gen3Database:
 
     async def increment_msg_count(self, user_id: int, guild_id: int) -> int:
         """Increment the message count for the user in the guild, creating row if needed."""
-        season_id = await self._get_active_season_id(guild_id)
+        season_id = await self._require_active_season_id(guild_id)
         query = (
             "INSERT INTO gen3.strikes (user_id, guild_id, season_id, strikes, msg_count) "
             "VALUES ($1, $2, $3, 0, 1) "
@@ -314,7 +368,7 @@ class Gen3Database:
 
     async def fetch_standings(self, guild_id: int):
         """Fetch active standings (strikes < 3), ordered by lowest strikes then msg_count desc."""
-        season_id = await self._get_active_season_id(guild_id)
+        season_id = await self._require_active_season_id(guild_id)
         query = (
             "SELECT user_id, strikes, msg_count FROM gen3.strikes "
             "WHERE guild_id = $1 AND season_id = $2 AND strikes < 3 "
@@ -324,7 +378,7 @@ class Gen3Database:
 
     async def fetch_struck_out(self, guild_id: int):
         """Fetch struck-out users (strikes >= 3), ordered by msg_count desc."""
-        season_id = await self._get_active_season_id(guild_id)
+        season_id = await self._require_active_season_id(guild_id)
         query = (
             "SELECT user_id, strikes, msg_count FROM gen3.strikes "
             "WHERE guild_id = $1 AND season_id = $2 AND strikes >= 3 "


### PR DESCRIPTION
### Motivation
- Ensure operations that depend on an active Gen3 season fail fast and predictably rather than silently using/creating seasons.
- Provide explicit start/end semantics so a new season cannot be started while one is active and so admins can end seasons without immediately creating a new one.
- Surface clear user-facing messages when there is no active season to avoid confusing errors during slash command use.

### Description
- Add `NoActiveSeasonError` to `gen3.utils.database` and introduce `start_season` and `end_active_season` methods to explicitly start and end seasons without implicit creation semantics.
- Replace the old `_get_active_season_id` helper with `_require_active_season_id` which raises `NoActiveSeasonError` when no active season exists, and change all strike/standings methods to call it.
- Update slash command handlers to check for and handle `NoActiveSeasonError` with user-friendly responses, including in `season new` (now uses `start_season` and reports if an active season already exists), `season end` (new subcommand), `remove_strikes`, `forgive`, `view_strikes`, `standings`, and several message-handling code paths to avoid operating when no season exists.
- Simplify `season new` response flow by removing legacy clearing logic and emitting a clear embed; add guidance to `season end` embed footer.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5d50c5edc83258755606d261cb98f)