### PR TITLE
Prefer animated attachments in Apply Effect context menu to preserve GIF/WebP outputs

### DIFF
--- a/emote/user_commands.py
+++ b/emote/user_commands.py
@@ -219,8 +219,22 @@ class UserCommands(commands.Cog):
             )
             return
 
-        image_attachment = next((att for att in message.attachments if att.content_type.startswith("image/")), None)
+        image_attachments = [
+            att for att in message.attachments
+            if att.content_type and att.content_type.startswith("image/")
+        ]
+
+        # Prefer animated sources first so effects like shake preserve expected output format.
+        image_attachment = next(
+            (att for att in image_attachments if att.filename.lower().endswith((".gif", ".webp"))),
+            image_attachments[0],
+        )
         image_buffer = await image_attachment.read()
+
+        # Prefer filename extension over Content-Type because Discord may normalize
+        # some attachment content types (e.g., animated uploads presented as image/jpeg).
+        attachment_ext = image_attachment.filename.rsplit(".", 1)[-1].lower() if "." in image_attachment.filename else ""
+        file_type = attachment_ext or image_attachment.content_type.split("/")[-1]
 
         # TODO: image compression / resize to be smaller
 
@@ -256,7 +270,7 @@ class UserCommands(commands.Cog):
         view = EffectView(
             available_options=available_options,
             image_buffer=image_buffer,
-            file_type=image_attachment.content_type.split("/")[-1],
+            file_type=file_type,
             timeout=180
         )
 


### PR DESCRIPTION
### Motivation
- The context-menu `Apply Effect` flow could pick the wrong attachment/type (e.g., a normalized `image/jpeg`) which caused effects that produce animated output (like `shake`) to end up as static JPGs instead of GIF/WebP. This change aims to choose the correct input so downstream effects keep expected animated formats.

### Description
- Update `handle_apply_effect` in `emote/user_commands.py` to gather image attachments into a list and prefer animated files with `filename` extensions `.gif` or `.webp` when available. 
- Derive `file_type` from the attachment filename extension first and fall back to the attachment `content_type` when the filename has no extension. 
- Pass the resolved `file_type` into `EffectView` so the pipeline and final output filename/format use the corrected type. 
- This change affects the app-command/context-menu path only (`Apply Effect`) and does not modify the `shake` effect implementation itself.

### Testing
- Ran `python -m pytest emote/tests/test_pipeline.py -q` to validate the pipeline behavior, but test collection failed due to the environment missing the `discord` dependency (`ModuleNotFoundError: No module named 'discord'`).
- No automated test failures related to the change were observed locally because full test execution could not complete in this environment due to the missing dependency.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b857365908325b875e545c2962a91)